### PR TITLE
Allow funnel token to carry application context information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    funneler (1.0.1)
+    funneler (1.1.0)
       jwt
 
 GEM

--- a/lib/funneler.rb
+++ b/lib/funneler.rb
@@ -30,14 +30,17 @@ module Funneler
       raise InvalidTokenError, "Invalid token '#{token}': #{e.message}"
     end
 
-    def build(route_generator:, params: {}, expires_in_days: nil)
+    def build(route_generator:, params: {}, expires_in_days: nil, meta: {})
       Funneler::FunnelFactory.build(route_generator: route_generator,
                                    params: params,
+                                   meta: meta,
                                    expires_in_days: expires_in_days)
     end
 
-    def from_routes(routes: {})
-      Funnel.new('routes' => routes, 'current_page_index' => 0)
+    def from_routes(routes: {}, meta: {})
+      Funnel.new('routes' => routes,
+                 'current_page_index' => 0,
+                 'meta' => meta)
     end
 
     def from_url(url:)

--- a/lib/funneler/funnel.rb
+++ b/lib/funneler/funnel.rb
@@ -31,6 +31,10 @@ module Funneler
       @url_cache[current_page_index]
     end
 
+    def meta
+      data['meta'] || {}
+    end
+
     def current_page_index
       data.fetch('current_page_index', 0)
     end
@@ -76,4 +80,3 @@ module Funneler
     end
   end
 end
-

--- a/lib/funneler/funnel_factory.rb
+++ b/lib/funneler/funnel_factory.rb
@@ -2,11 +2,13 @@ module Funneler
   class FunnelFactory
 
     class << self
-      def build(route_generator:, params: {}, expires_in_days: nil)
+      def build(route_generator:, params: {}, expires_in_days: nil, meta: {})
         return nil unless route_generator.respond_to?(:call)
 
         routes = route_generator.call(params)
-        Funnel.new('routes' => routes, 'expires_in_days' => expires_in_days)
+        Funnel.new('routes' => routes,
+                   'expires_in_days' => expires_in_days,
+                   'meta' => meta)
       end
     end
   end

--- a/lib/funneler/version.rb
+++ b/lib/funneler/version.rb
@@ -1,3 +1,3 @@
 module Funneler
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/funneler/funnel_factory_spec.rb
+++ b/spec/funneler/funnel_factory_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe Funneler::FunnelFactory do
     it 'returns a new funnel with the routes generated for the funnel type' do
       funnel = factory.build(route_generator: route_generator,
                              params: {},
+                             meta: { name: 'Santa' },
                              expires_in_days: 42)
       expect(funnel.data).to eq('routes' => ['a', 'b'],
-                                'expires_in_days' => 42)
+                                'expires_in_days' => 42,
+                                'meta' => {name: 'Santa'})
     end
   end
 end

--- a/spec/funneler/funnel_spec.rb
+++ b/spec/funneler/funnel_spec.rb
@@ -117,6 +117,14 @@ RSpec.describe Funneler::Funnel do
     end
   end
 
+  context '#meta' do
+    it 'exposes the application specific meta data' do
+      data = { 'meta' => {foo: :bar} }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.meta).to eq(foo: :bar)
+    end
+  end
+
   def verify_url(url, route:, current_page_index:)
     expect(url).to match(/^#{route}\?funnel_token=[\w\-_]+\.[\w\-_]+\.[\w\-_]/)
     new_funnel = funnel_from_url(url)

--- a/spec/funneler_spec.rb
+++ b/spec/funneler_spec.rb
@@ -56,7 +56,18 @@ RSpec.describe Funneler do
         new_funnel = Funneler.from_url(url: funnel.next_page)
         expect(new_funnel.data).to include('routes' => routes)
         expect(new_funnel.data).to include('current_page_index' => 1)
+        expect(funnel.data).to include('meta' => {})
       end
+    end
+  end
+
+  context ".from_routes" do
+    let(:routes) { ['/a', '/b'] }
+    it 'builds a funnel with the given routes and meta' do
+      funnel = Funneler.from_routes(routes: routes, meta: {name: 'Ryan'})
+      expect(funnel.data).to include('routes' => routes)
+      expect(funnel.data).to include('current_page_index' => 0)
+      expect(funnel.data).to include('meta' => {name: 'Ryan'})
     end
   end
 end


### PR DESCRIPTION
A funnel can now be generated with extra `context` information that will
be retained through out it's use.  This data can be useful for
applications wanting to carry around extra information outside of the
URL params.