### PR TITLE
Use next-gen ruby 2.6 executor for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ orbs:
   gem: doximity/gem-publisher@0
 
 executors:
-  ruby-latest:
+  ruby-2-6:
     resource_class: small
     docker:
-      - image: circleci/ruby:latest
+      - image: cimg/ruby:2.6
         environment:
           BUNDLE_VERSION: "~> 1.17"
 
@@ -33,7 +33,7 @@ version_tags_only: &version_tags_only
 
 jobs:
   build:
-    executor: ruby-latest
+    executor: ruby-2-6
     steps:
       - checkout
       - run:
@@ -79,7 +79,7 @@ workflows:
           <<: *master_only
       - gem/build:
           <<: *master_only
-          executor: ruby-latest
+          executor: ruby-2-6
           name: gem-build
           requires:
             - build
@@ -90,7 +90,7 @@ workflows:
           <<: *pr_only
       - gem/build:
           <<: *pr_only
-          executor: ruby-latest
+          executor: ruby-2-6
           name: gem-build
           requires:
             - build
@@ -114,7 +114,7 @@ workflows:
           <<: *version_tags_only
       - gem/build:
           <<: *version_tags_only
-          executor: ruby-latest
+          executor: ruby-2-6
           name: gem-build
           requires:
             - build


### PR DESCRIPTION
Pivotal Story: https://www.pivotaltracker.com/story/show/176417736

Due to the release of ruby 3, Ruby 2.x is no longer the latest ruby, so the "latest" image is no longer appropriate.