### PR TITLE
Add steppers to Funnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-12-08
+### Changed
+- Add ability to assign titles to each funnel step. Include helper methods to
+  `Funneler::Funnel` to generate a stepper and progress bar.
+
 ## [1.2.2] - 2020-02-21
 ### Changed
 - Release on RubyGems using gem-publisher CircleCI Orb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    funneler (1.2.2)
+    funneler (1.3.0)
       jwt
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,7 +30,30 @@ Or install it yourself as:
 2. Generate a token for a given set of routes, and route your user to
    the first page:
 ```ruby
-funnel = Funneler.build(routes: ['/welcome', '/setup', '/complete'])
+funnel = Funneler.from_routes(routes: ['/welcome', '/setup', '/complete'])
+redirect_to funnel.first_page
+```
+
+If you want create a progress bar for your funnel, you can specify the name for
+each step:
+```ruby
+funnel = Funneler.from_routes(
+  routes: [
+    ['/welcome', 'Welcome!'], ['/setup', 'Setup your account'], ['/complete', 'You are almost done!']
+  ]
+)
+redirect_to funnel.first_page
+```
+
+You can also use a route generator to encapsulate your route logic
+
+```ruby
+class CustomRouteGenerator
+  def self.call
+    ['/welcome', '/setup', '/complete']
+  end
+end
+funnel = Funneler.build(route_generator: CustomRouteGenerator)
 redirect_to funnel.first_page
 ```
 

--- a/lib/funneler/funnel.rb
+++ b/lib/funneler/funnel.rb
@@ -1,12 +1,14 @@
 module Funneler
   class Funnel
-
     attr_reader :data, :current_page_index
 
+    # Routes can be specified as either an array of routes (e.g ['/welcome',
+    # '/complete']), or an array of 2 items that include a route and a page
+    # title (e.g [['/welcome', 'Welcome!'], ['/complete', 'You are all done']])
     def initialize(data = {}, current_page_index = nil)
-      @data = data
-      @current_page_index = current_page_index || data.fetch("current_page_index", nil) || 0
-      @url_cache = Hash.new {|h, key| h[key] = generate_page_for_index(key) }
+      @data = unpack(data)
+      @current_page_index = (current_page_index || data.fetch("current_page_index", nil)).to_i
+      @url_cache = Hash.new { |h, key| h[key] = generate_page_for_index(key) }
     end
 
     def first_page(additional_params = {})
@@ -14,6 +16,30 @@ module Funneler
       return url if additional_params.empty?
 
       add_params_to_url(url, additional_params)
+    end
+
+    def next_step
+      titles[next_index]
+    end
+
+    def previous_step
+      return if previous_index == current_page_index
+
+      titles[previous_index]
+    end
+
+    def current_step
+      titles[current_page_index]
+    end
+
+    def stepper
+      titles.zip(Array.new(current_page_index) { |index| @url_cache[index] })
+    end
+
+    def progress_percentage
+      return 100 if routes.empty?
+
+      ((current_page_index + 1.0) / routes.length * 100).round
     end
 
     def next_page
@@ -33,7 +59,15 @@ module Funneler
     end
 
     def meta
-      data['meta'] || {}
+      data.fetch("meta", {})
+    end
+
+    def routes
+      data.fetch("routes", [])
+    end
+
+    def titles
+      data.fetch("titles", [])
     end
 
     def token
@@ -58,10 +92,6 @@ module Funneler
       uri.to_s
     end
 
-    def routes
-      data.fetch('routes', [])
-    end
-
     def next_index
       current_page_index.to_i + 1
     end
@@ -75,6 +105,29 @@ module Funneler
       index.nil? ||
         index < 0 ||
         index >= routes.length
+    end
+
+    # This method unpacks the routes and titles information from the original
+    # routes data
+    def unpack(data)
+      data["routes"] ||= []
+      data["titles"] ||= []
+
+      titles_from_routes = data["routes"].map { |route| Array(route)[1] }
+
+      # Fills the titles data from routes when it's present and there isn't
+      # already a title specified for that index
+      titles_from_routes.each.with_index do |title_from_route, index|
+        data["titles"][index] ||= title_from_route
+      end
+
+      # Remove title information from routes
+      data["routes"].map! { |route| Array(route)[0] }
+
+      # Remove any empty or incomplete data
+      data.delete_if { |key, value| value.class < Enumerable && (value.empty? || value.any?(&:nil?)) }
+
+      data
     end
   end
 end

--- a/lib/funneler/version.rb
+++ b/lib/funneler/version.rb
@@ -1,3 +1,3 @@
 module Funneler
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/spec/funneler/funnel_factory_spec.rb
+++ b/spec/funneler/funnel_factory_spec.rb
@@ -15,5 +15,19 @@ RSpec.describe Funneler::FunnelFactory do
                                 'expires_in_days' => 42,
                                 'meta' => {name: 'Santa'})
     end
+
+    context 'with step titles' do
+      let(:route_generator) { ->(_) { [['a', 'First page'], ['b', 'Second page']] } }
+
+      it 'returns a new funnel with the routes generated for the funnel type' do
+        funnel = factory.build(route_generator: route_generator,
+                               params: {},
+                               meta: { name: 'Santa' },
+                               expires_in_days: 42)
+        expect(funnel.routes).to eq(["a", "b"])
+        expect(funnel.titles).to eq(["First page", "Second page"])
+        expect(funnel.meta).to eq({ name: "Santa" })
+      end
+    end
   end
 end

--- a/spec/funneler/funnel_spec.rb
+++ b/spec/funneler/funnel_spec.rb
@@ -10,118 +10,215 @@ RSpec.describe Funneler::Funnel do
   before { allow(Funneler).to receive(:configuration).and_return(configuration) }
 
   context "#next_page" do
-    it 'returns nil when there are no routes' do
+    it "returns nil when there are no routes" do
       expect(Funneler::Funnel.new.next_page).to eq(nil)
     end
 
-    it 'returns the next route with a token parameter' do
-      data = { 'routes' => routes }
+    it "returns the next route with a token parameter" do
+      data = { "routes" => routes }
       url = Funneler::Funnel.new(data).next_page
-      verify_url(url, route: 'second', current_page_index: 1)
+      verify_url(url, route: "second", current_page_index: 1)
     end
 
-    it 'returns the page after the current index' do
-      data = { 'routes' => routes, 'current_page_index' => 1 }
+    it "returns the page after the current index" do
+      data = { "routes" => routes, "current_page_index" => 1 }
       url = Funneler::Funnel.new(data).next_page
-      verify_url(url, route: 'third', current_page_index: 2)
+      verify_url(url, route: "third", current_page_index: 2)
+    end
+  end
+
+  context "#next_step" do
+    let(:titles) { ['First page', 'Second page', 'Third page'] }
+
+    it "returns nil when there are no titles" do
+      expect(Funneler::Funnel.new.next_step).to eq(nil)
+    end
+
+    it "returns the page title after the current index" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 1 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.next_step).to eq("Third page")
+    end
+
+    it "returns no page title if there is no next page" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 2 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.next_step).to be_nil
     end
   end
 
   context "#previous_page" do
-    it 'returns nil when no default is specified and there are no routes' do
+    it "returns nil when no default is specified and there are no routes" do
       expect(Funneler::Funnel.new.previous_page).to eq(nil)
     end
 
-    it 'returns the previous route with a token parameter' do
-      data = { 'routes' => routes, 'current_page_index' => 2 }
+    it "returns the previous route with a token parameter" do
+      data = { "routes" => routes, "current_page_index" => 2 }
       url = Funneler::Funnel.new(data).previous_page
-      verify_url(url, route: 'second', current_page_index: 1)
+      verify_url(url, route: "second", current_page_index: 1)
     end
 
-    it 'returns the first page when the index is already the first page' do
-      data = { 'routes' => routes, 'current_page_index' => 0 }
+    it "returns the first page when the index is already the first page" do
+      data = { "routes" => routes, "current_page_index" => 0 }
       url = Funneler::Funnel.new(data).previous_page
-      verify_url(url, route: 'first', current_page_index: 0)
+      verify_url(url, route: "first", current_page_index: 0)
+    end
+  end
+
+  context "#previous_step" do
+    let(:titles) { ['First page', 'Second page', 'Third page'] }
+
+    it "returns nil when there are no titles" do
+      expect(Funneler::Funnel.new.previous_step).to eq(nil)
+    end
+
+    it "returns the previous page title" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 2 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.previous_step).to eq("Second page")
+    end
+
+    it "returns no page title if there is no previous page" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 0 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.previous_step).to be_nil
     end
   end
 
   context "#first_page" do
-    it 'returns nil when no routes are specified' do
+    it "returns nil when no routes are specified" do
       expect(Funneler::Funnel.new.first_page).to eq(nil)
     end
 
-    it 'returns the first route with a token parameter' do
-      data = { 'routes' => routes, 'current_page_index' => 42 }
+    it "returns the first route with a token parameter" do
+      data = { "routes" => routes, "current_page_index" => 42 }
       url = Funneler::Funnel.new(data).first_page
-      verify_url(url, route: 'first', current_page_index: 0)
+      verify_url(url, route: "first", current_page_index: 0)
     end
 
-    it 'allows for appending extra parameters to the url, including the current funnel_index' do
-      data = { 'routes' => routes, 'current_page_index' => 42 }
+    it "allows for appending extra parameters to the url, including the current funnel_index" do
+      data = { "routes" => routes, "current_page_index" => 42 }
       url = Funneler::Funnel.new(data).first_page(foo: :bar, a: 3)
-      verify_url(url, route: 'first', current_page_index: 0)
+      verify_url(url, route: "first", current_page_index: 0)
       expect(url).to match(/^first\?funnel_token=[\w\-_]+\.[\w\-_]+\.[\w\-_]+&funnel_index=0&foo=bar&a=3/)
     end
   end
 
-  context 'integration' do
-    let(:funnel) { Funneler::Funnel.new('routes' => routes) }
+  context "#current_step" do
+    let(:titles) { ['First page', 'Second page', 'Third page'] }
 
-    it 'allows moving between pages using the token' do
+    it "returns nil when there are no titles" do
+      expect(Funneler::Funnel.new.current_step).to eq(nil)
+    end
+
+    it "returns the current page title" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 2 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.current_step).to eq("Third page")
+    end
+  end
+
+  context "integration" do
+    let(:funnel) { Funneler::Funnel.new("routes" => routes) }
+
+    it "allows moving between pages using the token" do
       url = funnel.first_page
-      verify_url(url, route: 'first', current_page_index: 0)
+      verify_url(url, route: "first", current_page_index: 0)
 
       funnel = funnel_from_url(url)
       url = funnel.next_page
-      verify_url(url, route: 'second', current_page_index: 1)
+      verify_url(url, route: "second", current_page_index: 1)
 
       funnel = funnel_from_url(url)
       url = funnel.next_page
-      verify_url(url, route: 'third', current_page_index: 2)
+      verify_url(url, route: "third", current_page_index: 2)
 
       funnel = funnel_from_url(url)
       expect(funnel.next_page).to be_nil
 
       url = funnel.previous_page
-      verify_url(url, route: 'second', current_page_index: 1)
+      verify_url(url, route: "second", current_page_index: 1)
     end
   end
 
-  context '#is_last_page?' do
-    let(:routes) { ['first', 'second', 'third'] }
-    it 'is true when there are no routes' do
+  context "#is_last_page?" do
+    let(:routes) { ["first", "second", "third"] }
+    it "is true when there are no routes" do
       expect(Funneler::Funnel.new.is_last_page?).to eq(true)
     end
 
-    it 'is false when the index is not beyond the total routes' do
-      funnel = Funneler::Funnel.new('routes' => routes)
+    it "is false when the index is not beyond the total routes" do
+      funnel = Funneler::Funnel.new("routes" => routes)
       expect(funnel.is_last_page?).to eq(false)
     end
 
-    it 'is false when the index is not beyond the total routes' do
-      data = { 'routes' => routes, 'current_page_index' => 1  }
+    it "is false when the index is not beyond the total routes" do
+      data = { "routes" => routes, "current_page_index" => 1 }
       funnel = Funneler::Funnel.new(data)
       expect(funnel.is_last_page?).to eq(false)
     end
 
-    it 'is true when the index is on the last page' do
-      data = { 'routes' => [:a, :b], 'current_page_index' => 2 }
+    it "is true when the index is on the last page" do
+      data = { "routes" => [:a, :b], "current_page_index" => 2 }
       funnel = Funneler::Funnel.new(data)
       expect(funnel.is_last_page?).to eq(true)
     end
 
-    it 'is true when the index exceeds the # of routes' do
-      data = { 'routes' => [:a, :b], 'current_page_index' => 42 }
+    it "is true when the index exceeds the # of routes" do
+      data = { "routes" => [:a, :b], "current_page_index" => 42 }
       funnel = Funneler::Funnel.new(data)
       expect(funnel.is_last_page?).to eq(true)
     end
   end
 
-  context '#meta' do
-    it 'exposes the application specific meta data' do
-      data = { 'meta' => {foo: :bar} }
+  context "#meta" do
+    it "exposes the application specific meta data" do
+      data = { "meta" => { foo: :bar } }
       funnel = Funneler::Funnel.new(data)
       expect(funnel.meta).to eq(foo: :bar)
+    end
+  end
+
+  context "#progress_percentage" do
+    it "is 100 if there are no routes" do
+      funnel = Funneler::Funnel.new({})
+      expect(funnel.progress_percentage).to eq(100)
+    end
+
+    it "returns how far into the funnel is the current index" do
+      data = { "routes" => routes, "current_page_index" => 0 }
+      funnel = Funneler::Funnel.new(data)
+      expect(funnel.progress_percentage).to eq(33)
+    end
+  end
+
+  context "#stepper" do
+    let(:titles) { ['First page', 'Second page', 'Third page'] }
+
+    it "is empty if there are no page titles" do
+      funnel = Funneler::Funnel.new({ "routes" => routes })
+      expect(funnel.stepper).to be_empty
+    end
+
+    it "returns array of steps with title and route" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 1 }
+      stepper = Funneler::Funnel.new(data).stepper
+      expect(stepper.first[0]).to eq('First page')
+      verify_url(stepper.first[1], route: "first", current_page_index: 0)
+    end
+
+    it "omit route on current step" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 0 }
+      stepper = Funneler::Funnel.new(data).stepper
+      expect(stepper.first[0]).to eq('First page')
+      expect(stepper.first[1]).to be_nil
+    end
+
+    it "omit route on future step" do
+      data = { "routes" => routes.zip(titles), "current_page_index" => 1 }
+      stepper = Funneler::Funnel.new(data).stepper
+      expect(stepper.last[0]).to eq('Third page')
+      expect(stepper.last[1]).to be_nil
     end
   end
 
@@ -129,7 +226,7 @@ RSpec.describe Funneler::Funnel do
     expect(url).to match(/^#{route}\?funnel_token=[\w\-_]+\.[\w\-_]+\.[\w\-_]/)
     expect(url).to include("&funnel_index=#{current_page_index}")
     new_funnel = funnel_from_url(url)
-    expect(new_funnel.data).to include('current_page_index' => current_page_index)
+    expect(new_funnel.current_page_index).to eq(current_page_index)
   end
 
   def funnel_from_url(url)

--- a/spec/funneler_spec.rb
+++ b/spec/funneler_spec.rb
@@ -53,9 +53,23 @@ RSpec.describe Funneler do
       Timecop.freeze do
         funnel = Funneler.from_routes(routes: routes)
         new_funnel = Funneler.from_url(url: funnel.next_page)
-        expect(new_funnel.data).to include('routes' => routes)
-        expect(new_funnel.data).to include('current_page_index' => 1)
-        expect(funnel.data).to include('meta' => {})
+        expect(new_funnel.routes).to eq(routes)
+        expect(new_funnel.current_page_index).to eq(1)
+        expect(funnel.meta).to eq({})
+      end
+    end
+
+    context "with step titles" do
+      let(:routes) { [['/a', 'First page'], ['/b', 'Second page']] }
+      it 'extracts the funnel from the funnel_token in the given url' do
+        Timecop.freeze do
+          funnel = Funneler.from_routes(routes: routes)
+          new_funnel = Funneler.from_url(url: funnel.next_page)
+          expect(funnel.routes).to eq(['/a', '/b'])
+          expect(funnel.titles).to eq(['First page', 'Second page'])
+          expect(new_funnel.current_page_index).to eq(1)
+          expect(funnel.meta).to eq({})
+        end
       end
     end
   end
@@ -63,10 +77,21 @@ RSpec.describe Funneler do
   context ".from_routes" do
     let(:routes) { ['/a', '/b'] }
     it 'builds a funnel with the given routes and meta' do
-      funnel = Funneler.from_routes(routes: routes, meta: {name: 'Ryan'})
-      expect(funnel.data).to include('routes' => routes)
-      expect(funnel.data).to include('current_page_index' => 0)
-      expect(funnel.data).to include('meta' => {name: 'Ryan'})
+      funnel = Funneler.from_routes(routes: routes, meta: { name: 'Ryan' })
+      expect(funnel.routes).to eq(routes)
+      expect(funnel.current_page_index).to eq(0)
+      expect(funnel.meta).to eq({ name: "Ryan" })
+    end
+
+    context "with step titles" do
+      let(:routes) { [['/a', 'First page'], ['/b', 'Second page']] }
+      it 'builds a funnel with the given routes and meta' do
+        funnel = Funneler.from_routes(routes: routes, meta: { name: 'Ryan' })
+        expect(funnel.routes).to eq(['/a', '/b'])
+        expect(funnel.titles).to eq(['First page', 'Second page'])
+        expect(funnel.current_page_index).to eq(0)
+        expect(funnel.meta).to eq({ name: "Ryan" })
+      end
     end
   end
 end


### PR DESCRIPTION
Add page titles to funnels so they can help generate a stepper / progress bar.

A title is paired to each route, and it's stored in a separate structure for backward compatibility.

Titles are optional and we can still create funnels without them: `Funneler.from_routes(routes: ['/welcome', '/setup', '/complete'])`

You can create funnels and use them to generate a stepper like so:

```ruby
# in your controller
funnel = Funneler.from_routes(
  routes: [
    ['/welcome', 'Welcome!'], ['/setup', 'Setup your account'], ['/complete', 'You are almost done!']
  ]
)
redirect_to funnel.first_page

# in your view
ol.stepper
  - funnel.stepper.each do |(title, page)|
    li
      = page ? link_to(title, page) : tag.span(title)
```